### PR TITLE
Fix iRail/iRail#66

### DIFF
--- a/src/irail/stations/Stations.php
+++ b/src/irail/stations/Stations.php
@@ -28,7 +28,9 @@ class Stations
             $newstations->{"@id"} = $stations->{"@id"} . "?q=" . $query;
             $newstations->{"@context"} = $stations->{"@context"};
             $newstations->{"@graph"} = array();
-            
+
+            //https://github.com/iRail/iRail/issues/66
+            $query = str_replace("Bru.","Brussel", $query);
             //make sure something between brackets is ignored
             $query = preg_replace("/\s?\(.*?\)/i", "", $query);
             

--- a/tests/StationsTest.php
+++ b/tests/StationsTest.php
@@ -47,11 +47,13 @@ class StationsTest extends PHPUnit_Framework_TestCase
         $jsonld1 = Stations::getStations("Brussel");
         $jsonld2 = Stations::getStations("Brussels");
         $jsonld3 = Stations::getStations("Bruxelles");
+        $jsonld4 = Stations::getStations("Bru.-Noord / Brux.-Nord");
         
         //Assert whether it contains the right number of stations
         $this->assertCount(6,$jsonld1->{"@graph"});
         $this->assertCount(6,$jsonld2->{"@graph"});
         $this->assertCount(6,$jsonld3->{"@graph"});
+        $this->assertCount(1,$jsonld4->{"@graph"});
     }
 
     /**


### PR DESCRIPTION
Fixing https://github.com/iRail/iRail/issues/66

Sometimes Brussels North or other Brussels stations, when requested from the SNCB website in English, are used in a short form: Bru. ...