### PR TITLE
Fallback station names with ' as whitespace

### DIFF
--- a/src/irail/stations/Stations.php
+++ b/src/irail/stations/Stations.php
@@ -69,20 +69,26 @@ class Stations
             usort($stations_array, ['\irail\stations\Stations','cmp_stations_vehicle_frequency']);
 
             foreach ($stations_array as $station) {
-                if (preg_match('/.*'.$query.'.*/i', str_replace(' am ', ' ', self::normalizeAccents($station->{'name'})), $match)) {
+                $testStationName = str_replace(' am ', ' ', self::normalizeAccents($station->{'name'}));
+                if (preg_match('/.*'.$query.'.*/i', $testStationName, $match)
+                    || preg_match('/.*'.$query.'.*/i', str_replace('\'', ' ', $testStationName), $match)) {
                     $newstations->{'@graph'}[] = $station;
                     $count++;
                 } elseif (isset($station->alternative)) {
                     if (is_array($station->alternative)) {
                         foreach ($station->alternative as $alternative) {
-                            if (preg_match('/.*('.$query.').*/i', str_replace(' am ', ' ', self::normalizeAccents($alternative->{'@value'})), $match)) {
+                            $testStationName = str_replace(' am ', ' ', self::normalizeAccents($alternative->{'@value'}));
+                            if (preg_match('/.*('.$query.').*/i', $testStationName, $match)
+                                || preg_match('/.*('.$query.').*/i', str_replace('\'', ' ', $testStationName), $match)) {
                                 $newstations->{'@graph'}[] = $station;
                                 $count++;
                                 break;
                             }
                         }
                     } else {
-                        if (preg_match('/.*'.$query.'.*/i', str_replace(' am ', ' ', self::normalizeAccents($alternative->{'@value'})))) {
+                        $testStationName = str_replace(' am ', ' ', self::normalizeAccents($alternative->{'@value'}));
+                        if (preg_match('/.*'.$query.'.*/i', $testStationName)
+                            || preg_match('/.*('.$query.').*/i', str_replace('\'', ' ', $testStationName), $match)) {
                             $newstations->{'@graph'}[] = $station;
                             $count++;
                         }

--- a/tests/StationsTest.php
+++ b/tests/StationsTest.php
@@ -93,6 +93,12 @@ class StationsTest extends PHPUnit_Framework_TestCase
         $result6a = Stations::getStations('La Louviere- Centre');
         $result6b = Stations::getStations('La Louvière-Centre');
         $this->assertEquals($result6a->{'@graph'}[0]->{'@id'}, $result6b->{'@graph'}[0]->{'@id'});
+
+        $result7a = Stations::getStations('Vivier D Oie');
+        $result7b = Stations::getStations('Vivier D Oie / Diesdelle');
+        $result7c = Stations::getStations('Diesdelle/Vivier d\'Oie');
+        $this->assertEquals($result7a->{'@graph'}[0]->{'@id'}, $result7b->{'@graph'}[0]->{'@id'});
+        $this->assertEquals($result7b->{'@graph'}[0]->{'@id'}, $result7c->{'@graph'}[0]->{'@id'});
     }
 
     public function testId()


### PR DESCRIPTION
Fixes: http://api.irail.be/vehicle.php/?id=3468&lang=fr&date=261115&time=1901&format=JSON