### PR TITLE
update Capellen (L) location

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -628,7 +628,7 @@ http://irail.be/stations/NMBS/008200510,Bertrange Strassen,,,,,lu,6.060601,49.61
 http://irail.be/stations/NMBS/008200134,Clervaux,,,,,lu,6.031393,50.054724,17.147398843931
 http://irail.be/stations/NMBS/008200133,Drauffelt,,,,,lu,6.006106,50.017778,17.147398843931
 http://irail.be/stations/NMBS/008200120,Ettelbréck,Ettelbruck,Ettelbruck,Ettelbrück,,lu,6.104169,49.847496,17.147398843931
-http://irail.be/stations/NMBS/008200518,Kapellen,Capellen,Capellen,Capellen,,lu,5.990833,49.644996,26.222543352601
+http://irail.be/stations/NMBS/008200518,Kapellen,Capellen,Capellen,Capellen,,lu,5.982265,49.638463,26.222543352601
 http://irail.be/stations/NMBS/008200130,Kautebaach,Kautenbach,Kautenbach,Kautenbach,,lu,6.020003,49.952777,17.147398843931
 http://irail.be/stations/NMBS/008200520,Klengbetten,Kleinbettingen,Kleinbettingen,Kleinbettingen,,lu,5.916385,49.646389,26.832369942197
 http://irail.be/stations/NMBS/008200100,Lëtzebuerg,Luxembourg,Luxemburg,Luxemburg,,lu,6.133331,49.599996,146.60115606936


### PR DESCRIPTION
Looked up via [Google Maps](https://www.google.com/maps/place/49°38'18.5%22N+5°58'56.1%22E/@49.6384647,5.9811707,18z/data=!3m1!4b1!4m5!3m4!1s0x0:0x0!8m2!3d49.638463!4d5.982265)

fixes #59