### PR TITLE
Capellen (L) is always with C

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -628,7 +628,7 @@ http://irail.be/stations/NMBS/008200510,Bertrange Strassen,,,,,lu,6.060601,49.61
 http://irail.be/stations/NMBS/008200134,Clervaux,,,,,lu,6.031393,50.054724,17.147398843931
 http://irail.be/stations/NMBS/008200133,Drauffelt,,,,,lu,6.006106,50.017778,17.147398843931
 http://irail.be/stations/NMBS/008200120,Ettelbréck,Ettelbruck,Ettelbruck,Ettelbrück,,lu,6.104169,49.847496,17.147398843931
-http://irail.be/stations/NMBS/008200518,Kapellen,Capellen,Capellen,Capellen,,lu,5.982265,49.638463,26.222543352601
+http://irail.be/stations/NMBS/008200518,Capellen,Capellen,Capellen,Capellen,,lu,5.982265,49.638463,26.222543352601
 http://irail.be/stations/NMBS/008200130,Kautebaach,Kautenbach,Kautenbach,Kautenbach,,lu,6.020003,49.952777,17.147398843931
 http://irail.be/stations/NMBS/008200520,Klengbetten,Kleinbettingen,Kleinbettingen,Kleinbettingen,,lu,5.916385,49.646389,26.832369942197
 http://irail.be/stations/NMBS/008200100,Lëtzebuerg,Luxembourg,Luxemburg,Luxemburg,,lu,6.133331,49.599996,146.60115606936


### PR DESCRIPTION
https://nl.wikipedia.org/wiki/Capellen_(plaats)

It is however with `K` in Luxembourgish (a language we don't support).

fixes #60 