### PR TITLE
Use APC as in-memory store for extreme performance gains. #111

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   ],
   "require": {
     "ml/json-ld": "^1.0",
-    "cache/cache": "^0.3.0"
+    "cache/apcu-adapter": "^1.0",
+    "cache/array-adapter": "^1.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     }
   ],
   "require": {
-    "ml/json-ld": "^1.0"
+    "ml/json-ld": "^1.0",
+    "cache/cache": "^0.3.0"
   },
   "autoload": {
     "psr-0": {

--- a/src/irail/stations/Stations.php
+++ b/src/irail/stations/Stations.php
@@ -10,6 +10,7 @@ namespace irail\stations;
 
 use Cache\Adapter\Apc\ApcCachePool;
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\PHPArray\ArrayCachePool;
 
 class Stations
 {
@@ -31,7 +32,13 @@ class Stations
     public static function createCachePool()
     {
         if (self::$cache == null) {
-            self::$cache = new ApcCachePool();
+            // Try to use APC when available
+            if (extension_loaded('apc')) {
+                self::$cache = new ApcCachePool();
+            } else {
+                // Fall back to array cache
+                self::$cache = new ArrayCachePool();
+            }
         }
 
         return self::$cache;

--- a/src/irail/stations/Stations.php
+++ b/src/irail/stations/Stations.php
@@ -82,17 +82,7 @@ class Stations
         self::$cache->save($item);
     }
 
-    /**
-     * Gets you stations in a JSON-LD graph ordered by relevance to the optional query.
-     *
-     * @param string $query
-     *
-     * @todo @param string country shortcode for a country (e.g., be, de, fr...)
-     *
-     * @return object a JSON-LD graph with context
-     */
-    public static function getStations($query = '', $country = '', $sorted = false)
-    {
+    private static function loadJsonLd(){
         if (!isset(self::$stations)) {
             // try to load from cache. If not availabe, load from file.
             $csv_key = self::APC_PREFIX . 'csv';
@@ -104,8 +94,22 @@ class Stations
                 self::$stations = json_decode(file_get_contents(__DIR__.self::$stationsfilename));
                 self::setCache($csv_key,self::$stations);
             }
-
         }
+    }
+
+    /**
+     * Gets you stations in a JSON-LD graph ordered by relevance to the optional query.
+     *
+     * @param string $query
+     *
+     * @todo @param string country shortcode for a country (e.g., be, de, fr...)
+     *
+     * @return object a JSON-LD graph with context
+     */
+    public static function getStations($query = '', $country = '', $sorted = false)
+    {
+        self::loadJsonLd();
+
         if ($query && $query !== '') {
 
             // Escape all special characters for PSR6-compliant key.
@@ -289,9 +293,7 @@ class Stations
             $id = 'http://irail.be/stations/NMBS/'.$id;
         }
 
-        if (!isset(self::$stations)) {
-            self::$stations = json_decode(file_get_contents(__DIR__.self::$stationsfilename));
-        }
+        self::loadJsonLd();
 
         $stationsdocument = self::$stations;
 

--- a/tests/StationsTest.php
+++ b/tests/StationsTest.php
@@ -155,4 +155,86 @@ class StationsTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($result2->{'name'}, $brusselssouth->{'name'});
     }
+
+
+    function testPerformance()
+    {
+        apc_clear_cache();
+        // test sample should be large enough.
+        // 100 iterations of 50 stations for a good average.
+        $n = 10;
+
+        $time_pre = microtime(true);
+        for ($i = 0; $i < $n; $i++) {
+            // 51 stations, Brussels south at 8:00
+            // stations are in order of appearance.
+            // This should somewhat represent a real series of requests.
+            Stations::getStations("Brussels-South/Brussels-Midi");
+            Stations::getStations("Nivelles");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Antwerpen-Centraal");
+            Stations::getStations("Braine-Le-Comte");
+            Stations::getStations("Liege-Palais");
+            Stations::getStations("Oostende");
+            Stations::getStations("Brussels Airport - Zaventem");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Dendermonde");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Genk");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Tournai");
+            Stations::getStations("Charleroi-Sud");
+            Stations::getStations("Landen");
+            Stations::getStations("Louvain-La-Neuve-Univ.");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Sint-Niklaas");
+            Stations::getStations("Gent-Sint-Pieters");
+            Stations::getStations("Antwerpen-Centraal");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Brugge");
+            Stations::getStations("Nivelles");
+            Stations::getStations("Quievrain");
+            Stations::getStations("Brussels Airport - Zaventem");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Oudenaarde");
+            Stations::getStations("Leuven");
+            Stations::getStations("Essen");
+            Stations::getStations("Binche");
+            Stations::getStations("Leuven");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Luxembourg (l)");
+            Stations::getStations("Turnhout");
+            Stations::getStations("Braine-Le-Comte");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Kortrijk");
+            Stations::getStations("Dendermonde");
+            Stations::getStations("Antwerpen-Centraal");
+            Stations::getStations("Liege-Guillemins");
+            Stations::getStations("Oostende");
+            Stations::getStations("Brussels Airport - Zaventem");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Charleroi-Sud");
+            Stations::getStations("Tongeren");
+            Stations::getStations("Schaarbeek / Schaerbeek");
+            Stations::getStations("Amsterdam Cs (nl)");
+            Stations::getStations("Kortrijk");
+        }
+
+        $time_post = microtime(true);
+        $exec_time = $time_post - $time_pre;
+        $exec_time = ($exec_time * 1000) / $n;
+
+        $status = (extension_loaded('apc') && ini_get('apc.enabled') && ini_get('apc.enable_cli')) ? "enabled" : "disabled";
+
+        echo "Testing $n liveboards took an average of $exec_time ms for 1 liveboard, with APC $status.\n";
+
+        if ($status == "disabled") {
+            echo "Use '-d apc.enable_cli=1' in the phpunit argument to test with APC enabled.\n";
+        }
+
+        assert(extension_loaded('apc') && ini_get('apc.enabled'), "APC should be enabled!");
+    }
+
 }

--- a/tests/StationsTest.php
+++ b/tests/StationsTest.php
@@ -159,10 +159,13 @@ class StationsTest extends PHPUnit_Framework_TestCase
 
     function testPerformance()
     {
-        apc_clear_cache();
+        // clear cache for a good time measurement
+        $cache = Stations::createCachePool();
+        $cache->clear();
+
         // test sample should be large enough.
         // 100 iterations of 50 stations for a good average.
-        $n = 10;
+        $n = 100;
 
         $time_pre = microtime(true);
         for ($i = 0; $i < $n; $i++) {
@@ -226,15 +229,9 @@ class StationsTest extends PHPUnit_Framework_TestCase
         $exec_time = $time_post - $time_pre;
         $exec_time = ($exec_time * 1000) / $n;
 
-        $status = (extension_loaded('apc') && ini_get('apc.enabled') && ini_get('apc.enable_cli')) ? "enabled" : "disabled";
+        echo "Testing $n liveboards took an average of $exec_time ms for 1 liveboard, using " . get_class($cache) . "\n";
+        echo "Note: When using APC, use '-d apc.enable_cli=1' in the phpunit argument to test with APC enabled.\n";
 
-        echo "Testing $n liveboards took an average of $exec_time ms for 1 liveboard, with APC $status.\n";
-
-        if ($status == "disabled") {
-            echo "Use '-d apc.enable_cli=1' in the phpunit argument to test with APC enabled.\n";
-        }
-
-        assert(extension_loaded('apc') && ini_get('apc.enabled'), "APC should be enabled!");
     }
 
 }


### PR DESCRIPTION
As tested in #111, in-memory caching provides serious performance gains.

This PR includes APC support for getStations and getStationById. Results of both functions are cached. This results in extreme performance gains up to 99%. This might have serious (positive) consequences for projects depending on this library. 

See issue #111 for an in-depth review of multiple possible solutions and why APC was chosen.

This PR will require APC available on the server. APC keys have a prefix to prevent key collisions.

Testing requires the argument '-d apc.enable_cli=1', or  apc.enable_cli should be set in php.ini.