### PR TITLE
Name change for several stations on 11/06/2017

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -274,7 +274,7 @@ http://irail.be/stations/NMBS/008863115,Jambes,,,,,be,4.876144,50.454843,45.2427
 http://irail.be/stations/NMBS/008863354,Jambes-Est,,,,,be,4.880261,50.454798,27.205202312139
 http://irail.be/stations/NMBS/008871175,Jamioulx,,,,,be,4.411294,50.352896,15.182080924855
 http://irail.be/stations/NMBS/008884566,Jemappes,,,,,be,3.885587,50.452577,58.341040462428
-http://irail.be/stations/NMBS/008864006,Jemelle,,,,,be,5.266698,50.160401,42.754335260116
+http://irail.be/stations/NMBS/008864006,Rochefort-Jemelle,,,,,be,5.266698,50.160401,42.754335260116
 http://irail.be/stations/NMBS/008843158,Jemeppe-sur-Meuse,,,,,be,5.497874,50.618446,25.468208092486
 http://irail.be/stations/NMBS/008874724,Jemeppe-sur-Sambre,,,,,be,4.662632,50.45095,41.528901734104
 http://irail.be/stations/NMBS/008812047,Jette,,,,,be,4.32622,50.880833,95.676300578035
@@ -288,7 +288,7 @@ http://irail.be/stations/NMBS/008832375,Kiewit,,,,,be,5.350226,50.954841,39.4768
 http://irail.be/stations/NMBS/008821451,Kijkuit,,,,,be,4.467315,51.378664,22.242774566474
 http://irail.be/stations/NMBS/008891660,Knokke,,,,,be,3.285188,51.339894,19.670520231214
 http://irail.be/stations/NMBS/008892320,Koksijde,Coxyde,,,,be,2.65277,51.079197,19.823699421965
-http://irail.be/stations/NMBS/008821311,Kontich,,,,,be,4.476358,51.134023,31.939306358382
+http://irail.be/stations/NMBS/008821311,Kontich-Lint,,,,,be,4.476358,51.134023,31.939306358382
 http://irail.be/stations/NMBS/008892403,Kortemark,,,,,be,3.043459,51.025244,19.823699421965
 http://irail.be/stations/NMBS/008811254,Kortenberg,,,,,be,4.543301,50.893067,50.621387283237
 http://irail.be/stations/NMBS/008896008,Kortrijk,Courtrai,,,,be,3.264549,50.824506,153.11560693642
@@ -336,7 +336,7 @@ http://irail.be/stations/NMBS/008832565,Lommel,,,,,be,5.312031,51.211564,18.5433
 http://irail.be/stations/NMBS/008822111,Londerzeel,,,,,be,4.299073,51.009091,36.341040462428
 http://irail.be/stations/NMBS/008861416,Lonzée,,,,,be,4.7201,50.551935,30.820809248555
 http://irail.be/stations/NMBS/008814357,Lot,,,,,be,4.273696,50.766364,49.054913294798
-http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve-Université,,,,,be,4.615745,50.669793,79.942196531792
+http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve,,,,,be,4.615745,50.669793,79.942196531792
 http://irail.be/stations/NMBS/008863156,Lustin,,,,,be,4.877071380615234,50.369000316323856,34.167630057803
 http://irail.be/stations/NMBS/008871308,Luttre,,,,,be,4.38412,50.505856,101.96242774566
 http://irail.be/stations/NMBS/008886041,Maffle,,,,,be,3.800117,50.614356,26.037572254335

--- a/stations.csv
+++ b/stations.csv
@@ -336,7 +336,7 @@ http://irail.be/stations/NMBS/008832565,Lommel,,,,,be,5.312031,51.211564,18.5433
 http://irail.be/stations/NMBS/008822111,Londerzeel,,,,,be,4.299073,51.009091,36.341040462428
 http://irail.be/stations/NMBS/008861416,Lonzée,,,,,be,4.7201,50.551935,30.820809248555
 http://irail.be/stations/NMBS/008814357,Lot,,,,,be,4.273696,50.766364,49.054913294798
-http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve,,,,,be,4.615745,50.669793,79.942196531792
+http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve-Université,,,,,be,4.615745,50.669793,79.942196531792
 http://irail.be/stations/NMBS/008863156,Lustin,,,,,be,4.877071380615234,50.369000316323856,34.167630057803
 http://irail.be/stations/NMBS/008871308,Luttre,,,,,be,4.38412,50.505856,101.96242774566
 http://irail.be/stations/NMBS/008886041,Maffle,,,,,be,3.800117,50.614356,26.037572254335

--- a/stops.csv
+++ b/stops.csv
@@ -106,9 +106,9 @@ http://irail.be/stations/NMBS/008811601#10,http://irail.be/stations/NMBS/0088116
 http://irail.be/stations/NMBS/008811601#11,http://irail.be/stations/NMBS/008811601,4.56936,50.673667,Ottignies,11
 http://irail.be/stations/NMBS/008811635#1,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,1
 http://irail.be/stations/NMBS/008811635#2,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,2
-http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,1
-http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,2
-http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,3
+http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,1
+http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,2
+http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,3
 http://irail.be/stations/NMBS/008811718#1,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,1
 http://irail.be/stations/NMBS/008811718#2,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,2
 http://irail.be/stations/NMBS/008811726#1,http://irail.be/stations/NMBS/008811726,4.604778,50.716267,Wavre,1
@@ -331,10 +331,10 @@ http://irail.be/stations/NMBS/008821238#1,http://irail.be/stations/NMBS/00882123
 http://irail.be/stations/NMBS/008821238#2,http://irail.be/stations/NMBS/008821238,4.455737,51.171256,Mortsel-Oude God,2
 http://irail.be/stations/NMBS/008821246#1,http://irail.be/stations/NMBS/008821246,4.468843,51.169027,Mortsel-Liersesteenweg,1
 http://irail.be/stations/NMBS/008821246#2,http://irail.be/stations/NMBS/008821246,4.468843,51.169027,Mortsel-Liersesteenweg,2
-http://irail.be/stations/NMBS/008821311#1,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich,1
-http://irail.be/stations/NMBS/008821311#2,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich,2
-http://irail.be/stations/NMBS/008821311#3,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich,3
-http://irail.be/stations/NMBS/008821311#4,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich,4
+http://irail.be/stations/NMBS/008821311#1,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich-Lint,1
+http://irail.be/stations/NMBS/008821311#2,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich-Lint,2
+http://irail.be/stations/NMBS/008821311#3,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich-Lint,3
+http://irail.be/stations/NMBS/008821311#4,http://irail.be/stations/NMBS/008821311,4.476358,51.134023,Kontich-Lint,4
 http://irail.be/stations/NMBS/008821337#1,http://irail.be/stations/NMBS/008821337,4.465157,51.154114,Hove,1
 http://irail.be/stations/NMBS/008821337#2,http://irail.be/stations/NMBS/008821337,4.465157,51.154114,Hove,2
 http://irail.be/stations/NMBS/008821337#3,http://irail.be/stations/NMBS/008821337,4.465157,51.154114,Hove,3
@@ -818,12 +818,12 @@ http://irail.be/stations/NMBS/008863842#3,http://irail.be/stations/NMBS/00886384
 http://irail.be/stations/NMBS/008863842#4,http://irail.be/stations/NMBS/008863842,5.006074,50.189868,Houyet,4
 http://irail.be/stations/NMBS/008863867#1,http://irail.be/stations/NMBS/008863867,4.95684,50.11443,Beauraing,1
 http://irail.be/stations/NMBS/008863867#2,http://irail.be/stations/NMBS/008863867,4.95684,50.11443,Beauraing,2
-http://irail.be/stations/NMBS/008864006#1,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,1
-http://irail.be/stations/NMBS/008864006#2,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,2
-http://irail.be/stations/NMBS/008864006#3,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,3
-http://irail.be/stations/NMBS/008864006#4,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,4
-http://irail.be/stations/NMBS/008864006#5,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,5
-http://irail.be/stations/NMBS/008864006#6,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Jemelle,6
+http://irail.be/stations/NMBS/008864006#1,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,1
+http://irail.be/stations/NMBS/008864006#2,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,2
+http://irail.be/stations/NMBS/008864006#3,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,3
+http://irail.be/stations/NMBS/008864006#4,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,4
+http://irail.be/stations/NMBS/008864006#5,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,5
+http://irail.be/stations/NMBS/008864006#6,http://irail.be/stations/NMBS/008864006,5.266698,50.160401,Rochefort-Jemelle,6
 http://irail.be/stations/NMBS/008864311#1,http://irail.be/stations/NMBS/008864311,5.276784,50.132759,Forrières,1
 http://irail.be/stations/NMBS/008864311#2,http://irail.be/stations/NMBS/008864311,5.276784,50.132759,Forrières,2
 http://irail.be/stations/NMBS/008864337#1,http://irail.be/stations/NMBS/008864337,5.280524,50.0906,Grupont,1

--- a/stops.csv
+++ b/stops.csv
@@ -106,9 +106,9 @@ http://irail.be/stations/NMBS/008811601#10,http://irail.be/stations/NMBS/0088116
 http://irail.be/stations/NMBS/008811601#11,http://irail.be/stations/NMBS/008811601,4.56936,50.673667,Ottignies,11
 http://irail.be/stations/NMBS/008811635#1,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,1
 http://irail.be/stations/NMBS/008811635#2,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,2
-http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,1
-http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,2
-http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,3
+http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,1
+http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,2
+http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,3
 http://irail.be/stations/NMBS/008811718#1,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,1
 http://irail.be/stations/NMBS/008811718#2,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,2
 http://irail.be/stations/NMBS/008811726#1,http://irail.be/stations/NMBS/008811726,4.604778,50.716267,Wavre,1


### PR DESCRIPTION
On 11/06/2017 several NMBS stations will have their name changed, this PR updates the iRail station database with their new names.

Press release: [belgianrail.be](http://www.belgianrail.be/fr/corporate/Presse/Presse-releases/02_06_2017_3.aspx)

I guess the link associated with the station stays the same in this case?