### PR TITLE
Renamed Louvain La Neuve Universite to Louvain La Neuve #119

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -336,7 +336,7 @@ http://irail.be/stations/NMBS/008832565,Lommel,,,,,be,5.312031,51.211564,18.5433
 http://irail.be/stations/NMBS/008822111,Londerzeel,,,,,be,4.299073,51.009091,36.341040462428
 http://irail.be/stations/NMBS/008861416,Lonzée,,,,,be,4.7201,50.551935,30.820809248555
 http://irail.be/stations/NMBS/008814357,Lot,,,,,be,4.273696,50.766364,49.054913294798
-http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve-Université,,,,,be,4.615745,50.669793,79.942196531792
+http://irail.be/stations/NMBS/008811676,Louvain-la-Neuve,,,,,be,4.615745,50.669793,79.942196531792
 http://irail.be/stations/NMBS/008863156,Lustin,,,,,be,4.877071380615234,50.369000316323856,34.167630057803
 http://irail.be/stations/NMBS/008871308,Luttre,,,,,be,4.38412,50.505856,101.96242774566
 http://irail.be/stations/NMBS/008886041,Maffle,,,,,be,3.800117,50.614356,26.037572254335

--- a/stops.csv
+++ b/stops.csv
@@ -106,9 +106,9 @@ http://irail.be/stations/NMBS/008811601#10,http://irail.be/stations/NMBS/0088116
 http://irail.be/stations/NMBS/008811601#11,http://irail.be/stations/NMBS/008811601,4.56936,50.673667,Ottignies,11
 http://irail.be/stations/NMBS/008811635#1,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,1
 http://irail.be/stations/NMBS/008811635#2,http://irail.be/stations/NMBS/008811635,4.575302,50.69214,Limal,2
-http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,1
-http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,2
-http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve-Université,3
+http://irail.be/stations/NMBS/008811676#1,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,1
+http://irail.be/stations/NMBS/008811676#2,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,2
+http://irail.be/stations/NMBS/008811676#3,http://irail.be/stations/NMBS/008811676,4.615745,50.669793,Louvain-la-Neuve,3
 http://irail.be/stations/NMBS/008811718#1,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,1
 http://irail.be/stations/NMBS/008811718#2,http://irail.be/stations/NMBS/008811718,4.594746,50.707772,Bierges-Walibi,2
 http://irail.be/stations/NMBS/008811726#1,http://irail.be/stations/NMBS/008811726,4.604778,50.716267,Wavre,1


### PR DESCRIPTION
Solves #119 - Louvain la neuve has a new name 
Related to #116 - fixes my wrong judgement there: this name change was indeed in small letters at the bottom in the press release.