### PR TITLE
Added missing stations compared to GTFS feed

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -646,3 +646,13 @@ http://irail.be/stations/NMBS/008815016,Thurn en Taxis/Tour et Taxis,Tour et Tax
 http://irail.be/stations/NMBS/008811403,Mouterij/Germoir,Germoir,Mouterij,Germoir,Mouterij,be,4.37866,50.829929,0
 http://irail.be/stations/NMBS/008814472,Arcaden/Arcades,Arcades,Arcaden,,,be,4.398333,50.809722,0
 http://irail.be/stations/NMBS/008400131,Breda,,,,,nl,4.7764000000,51.5944590000,0
+http://irail.be/stations/NMBS/008200128,Michelau,,,,,lu,6.09149000,49.8972900,0
+http://irail.be/stations/NMBS/008829009,Essen-Grens,,,,,be,4.4489300051.4690900,0
+http://irail.be/stations/NMBS/008849023,Hergenrath-Frontiere,,,,,be,6.04126900,50.7189550,0
+http://irail.be/stations/NMBS/008849064,Vise-Frontiere,,,,,be,5.70290300,50.7584130,0
+http://irail.be/stations/NMBS/008849072,Gouvy-Frontiere,,,,,be,5.96861300,50.1716530,0
+http://irail.be/stations/NMBS/008869047,Athus-Frontiere,,,,,be,5.82493200,49.5517490,0
+http://irail.be/stations/NMBS/008869054,Sterpenich-Frontiere,,,,,be,5.90415000,49.6439600,0
+http://irail.be/stations/NMBS/008869088,Aubange-Frontiere-Luxembourg,,,,,be,5.82630700,49.5494550,0
+http://irail.be/stations/NMBS/008889011,Mouscron-Frontiere,,,,,be,3.19608600,50.7217160,0
+http://irail.be/stations/NMBS/008889045,Blandain-Frontiere,,,,,be,3.26373000,50.6174900,0


### PR DESCRIPTION
Added missing stations compared to stops.txt in the official GTFS feed. Most of these are border stations, but the fact that they are included in the GTFS means NMBS could start using them all of a sudden.

Need feedback and discussion regarding to merge or not to merge this PR.