### PR TITLE
Update names of “Liège-Jonfosse” and “Liège-Palais”

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -378,8 +378,8 @@ http://irail.be/stations/NMBS/008032572,Limburg Süd,,,,,de,8.096112,50.3825,0,
 http://irail.be/stations/NMBS/008814142,Linkebeek,,,,,be,4.339434,50.773681,181.946429,300
 http://irail.be/stations/NMBS/008891629,Lissewege,,,,,be,3.194505,51.294714,26.303571,300
 http://irail.be/stations/NMBS/008841004,Liège-Guillemins,,Luik-Guillemins,,,be,5.566695,50.62455,377.125,300
-http://irail.be/stations/NMBS/008841558,Liège-Jonfosse,,Luik-Jonfosse,,,be,5.561131,50.640299,203.767857,300
-http://irail.be/stations/NMBS/008841525,Liege-Saint-Lambert,,Luik-Saint-Lambert,,,be,5.570453,50.646349,203.767857,300
+http://irail.be/stations/NMBS/008841558,Liège-Carré,,Luik-Carre,,,be,5.561131,50.640299,203.767857,300
+http://irail.be/stations/NMBS/008841525,Liège-Saint-Lambert,,Luik-Sint-Lambertus,,,be,5.570453,50.646349,203.767857,300
 http://irail.be/stations/NMBS/008871712,Lobbes,,,,,be,4.260958,50.346469,30.223214,300
 http://irail.be/stations/NMBS/008872306,Lodelinsart,,,,,be,4.462946,50.432451,34.866071,300
 http://irail.be/stations/NMBS/008894201,Lokeren,,,,,be,3.987794,51.108062,213.1875,240


### PR DESCRIPTION
This fixes issue #134.

I did some tests with the stations autocomplete on the SNCB / NMBS website but they don’t really seem to have any “official” new names for these two stations (they just translate “Liège” to “Lüttich” in German).

Edit: what I mean is no “official” new names **for languages other than Dutch and French** (i.e. English and German).