### PR TITLE
Added Antwerpen-Linkeroever station

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -32,6 +32,7 @@ http://irail.be/stations/NMBS/008821121,Antwerpen-Berchem,Anvers-Berchem,,,Antwe
 http://irail.be/stations/NMBS/008821006,Antwerpen-Centraal,Anvers-Central,,,Antwerp-Central,BE00037,FN,be,4.421101,51.2172,622.626039,300
 http://irail.be/stations/NMBS/008821030,Antwerpen-Dam,Anvers-Dam,Antwerpen-Dam,,,BE00038,FNDM,be,4.42623800,51.2319910,0,
 http://irail.be/stations/NMBS/008821048,Antwerpen-Haven,Anvers-Haven,,,Antwerp-Haven,BE00030,FNH,be,4.379086,51.289968,0,
+http://irail.be/stations/NMBS/008894839,Antwerpen-Linkeroever,Anvers-Linkeroever,,,Antwerp-Linkeroever,,,be,4.360044,51.215685,0,
 http://irail.be/stations/NMBS/008821063,Antwerpen-Luchtbal,Anvers-Luchtbal,,,Antwerp-Luchtbal,BE00042,FNLB,be,4.425029,51.244132,109.772853,300
 http://irail.be/stations/NMBS/008821089,Antwerpen-Noorderdokken,Anvers-Noorderdokken,,,Antwerp-Noorderdokken,BE00058,AND,be,4.427906,51.261643,86.645429,240
 http://irail.be/stations/NMBS/008821022,Antwerpen-Oost,Anvers-Est,,,Antwerp-East,BE00061,GNS,be,4.436392,51.207357,0,


### PR DESCRIPTION
Adds NMBS station 8894839 (Antwerpen-Linkeroever), the temporary station reopened on the left bank during the Antwerp premetro tunnel works.

- URI: http://irail.be/stations/NMBS/008894839                              
- Coordinates: 51.215685, 4.360044                                            
- taf-tap-code / telegraph-code left empty (unknown);